### PR TITLE
Improve Users#create validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Hash password before storing user to the database ([@bakku](https://github.com/bakku), [#2](https://github.com/bakku/easyalert/pull/2));
+- Improve validation of user creation endpoint ([@bakku](https://github.com/bakku), [#6](https://github.com/bakku/easyalert/pull/6));
 
 [Unreleased]: https://github.com/bakku/easyalert/compare/b6283ea...HEAD

--- a/postgres/user.go
+++ b/postgres/user.go
@@ -2,8 +2,10 @@ package postgres
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/bakku/easyalert"
+	"github.com/lib/pq"
 )
 
 // UserRepository is a postgres implementation of the UserRepository interface
@@ -71,6 +73,12 @@ func (repo UserRepository) CreateUser(user easyalert.User) (easyalert.User, erro
 	err := row.Scan(&user.ID, &user.CreatedAt, &user.UpdatedAt)
 
 	if err != nil {
+		if pqErr, ok := err.(*pq.Error); ok {
+			if pqErr.Constraint == "users_email_key" {
+				return easyalert.User{}, errors.New("Email is already taken.")
+			}
+		}
+
 		return easyalert.User{}, err
 	}
 
@@ -94,7 +102,7 @@ func (repo UserRepository) UpdateUser(user easyalert.User) (easyalert.User, erro
 			return easyalert.User{}, easyalert.ErrRecordDoesNotExist
 		}
 
-		return easyalert.User{}, err
+		return easyalert.User{}, errors.New("User could not be created. Verify that you sent valid data.")
 	}
 
 	return user, nil

--- a/web/api/users_handler.go
+++ b/web/api/users_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -46,9 +47,9 @@ func (h CreateUsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user := easyalert.User{
-		Email:          userBody.Email,
-		Token:          token,
-		Admin:          false,
+		Email: userBody.Email,
+		Token: token,
+		Admin: false,
 	}
 
 	err = user.HashPassword(userBody.Password)
@@ -59,7 +60,7 @@ func (h CreateUsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	user, err = h.UserRepo.CreateUser(user)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "User could not be created. Verify that you sent valid data.")
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("%v", err))
 		return
 	}
 

--- a/web/api/users_handler.go
+++ b/web/api/users_handler.go
@@ -40,6 +40,11 @@ func (h CreateUsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if userBody.Email == "" || userBody.Password == "" {
+		writeError(w, http.StatusBadRequest, "Empty email or password.")
+		return
+	}
+
 	token, err := random.String(32)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "could not generate token")

--- a/web/api/users_handler_test.go
+++ b/web/api/users_handler_test.go
@@ -29,12 +29,12 @@ func TestPOSTUsers_ShouldReturnErrorIfUserWasGivenIncorrectly(t *testing.T) {
 	require.Equal(t, "{\n  \"error\": \"invalid json\"\n}", rr.Body.String())
 }
 
-func TestPOSTUsers_ShouldReturnErrorIfUserCouldNotBeSaved(t *testing.T) {
+func TestPOSTUsers_ShouldReturnErrorFromDatabase(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	userRepo := mocks.NewMockUserRepository(mockCtrl)
-	userRepo.EXPECT().CreateUser(gomock.Any()).Return(easyalert.User{}, errors.New("invalid email"))
+	userRepo.EXPECT().CreateUser(gomock.Any()).Return(easyalert.User{}, errors.New("Email is already taken."))
 
 	payload := `
 		{
@@ -53,7 +53,7 @@ func TestPOSTUsers_ShouldReturnErrorIfUserCouldNotBeSaved(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
-	require.Equal(t, "{\n  \"error\": \"User could not be created. Verify that you sent valid data.\"\n}", rr.Body.String())
+	require.Equal(t, "{\n  \"error\": \"Email is already taken.\"\n}", rr.Body.String())
 }
 
 func TestPOSTUsers_ShouldCreateUser(t *testing.T) {

--- a/web/api/users_handler_test.go
+++ b/web/api/users_handler_test.go
@@ -56,6 +56,32 @@ func TestPOSTUsers_ShouldReturnErrorFromDatabase(t *testing.T) {
 	require.Equal(t, "{\n  \"error\": \"Email is already taken.\"\n}", rr.Body.String())
 }
 
+func TestPOSTUsers_ShouldNotAcceptEmptyEmailOrPassword(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(mockCtrl)
+
+	payload := `
+		{
+			"email" : "",
+			"password" : ""
+		}
+	`
+
+	req, err := http.NewRequest("POST", "/api/v1/users", strings.NewReader(payload))
+	require.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := api.CreateUsersHandler{
+		UserRepo: userRepo,
+	}
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Equal(t, "{\n  \"error\": \"Empty email or password.\"\n}", rr.Body.String())
+}
+
 func TestPOSTUsers_ShouldCreateUser(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
Fixes #4 

This PR adds a proper validation to the `POST /users` endpoint. It catches two error causes:
- Email is already taken
- Empty email or password sent