### PR TITLE
Add Content-Type application/json to all API responses

### DIFF
--- a/web/api/users_handler.go
+++ b/web/api/users_handler.go
@@ -83,6 +83,7 @@ func (h CreateUsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte(body))
 }

--- a/web/api/users_handler_test.go
+++ b/web/api/users_handler_test.go
@@ -26,6 +26,7 @@ func TestPOSTUsers_ShouldReturnErrorIfUserWasGivenIncorrectly(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusUnprocessableEntity, rr.Code)
+	require.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
 	require.Equal(t, "{\n  \"error\": \"invalid json\"\n}", rr.Body.String())
 }
 
@@ -53,6 +54,7 @@ func TestPOSTUsers_ShouldReturnErrorFromDatabase(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
 	require.Equal(t, "{\n  \"error\": \"Email is already taken.\"\n}", rr.Body.String())
 }
 
@@ -79,6 +81,7 @@ func TestPOSTUsers_ShouldNotAcceptEmptyEmailOrPassword(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
 	require.Equal(t, "{\n  \"error\": \"Empty email or password.\"\n}", rr.Body.String())
 }
 
@@ -116,5 +119,6 @@ func TestPOSTUsers_ShouldCreateUser(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusCreated, rr.Code)
+	require.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
 	require.Equal(t, "{\n  \"token\": \"12345\"\n}", rr.Body.String())
 }

--- a/web/api/util.go
+++ b/web/api/util.go
@@ -18,6 +18,7 @@ func prettifyJSON(in string) (string, error) {
 }
 
 func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(status)
 	body, _ := prettifyJSON("{\"error\":\"" + message + "\"}")
 	w.Write([]byte(body))


### PR DESCRIPTION
Fixes #5 

This PR adds the `Content-Type: application/json` header to all API responses.