### PR TITLE
Auth endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Hash password before storing user to the database ([@bakku](https://github.com/bakku), [#2](https://github.com/bakku/easyalert/pull/2));
 - Improve validation of user creation endpoint ([@bakku](https://github.com/bakku), [#6](https://github.com/bakku/easyalert/pull/6));
+- Add application/json Content-Type to all API responses ([@bakku](https://github.com/bakku), [#7](https://github.com/bakku/easyalert/pull/7));
+- Add auth endpoint to let a user fetch his token ([@bakku](https://github.com/bakku), [#8](https://github.com/bakku/easyalert/pull/8));
 
 [Unreleased]: https://github.com/bakku/easyalert/compare/b6283ea...HEAD

--- a/mocks/user.go
+++ b/mocks/user.go
@@ -34,16 +34,21 @@ func (m *MockUserRepository) EXPECT() *MockUserRepositoryMockRecorder {
 }
 
 // FindUser mocks base method
-func (m *MockUserRepository) FindUser(ID uint) (easyalert.User, error) {
-	ret := m.ctrl.Call(m, "FindUser", ID)
+func (m *MockUserRepository) FindUser(query string, params ...interface{}) (easyalert.User, error) {
+	varargs := []interface{}{query}
+	for _, a := range params {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FindUser", varargs...)
 	ret0, _ := ret[0].(easyalert.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindUser indicates an expected call of FindUser
-func (mr *MockUserRepositoryMockRecorder) FindUser(ID interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUser", reflect.TypeOf((*MockUserRepository)(nil).FindUser), ID)
+func (mr *MockUserRepositoryMockRecorder) FindUser(query interface{}, params ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{query}, params...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUser", reflect.TypeOf((*MockUserRepository)(nil).FindUser), varargs...)
 }
 
 // FindUsers mocks base method

--- a/postgres/user.go
+++ b/postgres/user.go
@@ -14,14 +14,14 @@ type UserRepository struct {
 }
 
 // FindUser fetches a user by ID and returns it. If the user does not exist it will return easyalert.ErrRecordDoesNotExist.
-func (repo UserRepository) FindUser(ID uint) (easyalert.User, error) {
+func (repo UserRepository) FindUser(query string, params ...interface{}) (easyalert.User, error) {
 	var user easyalert.User
 
-	row := repo.DB.QueryRow(`
-				SELECT id, email, password_digest, token, admin, created_at, updated_at
-				FROM users
-				WHERE id = $1
-			`, ID)
+	baseQuery := `
+		SELECT id, email, password_digest, token, admin, created_at, updated_at
+		FROM users
+	`
+	row := repo.DB.QueryRow(baseQuery+query, params...)
 
 	err := row.Scan(&user.ID, &user.Email, &user.PasswordDigest, &user.Token, &user.Admin, &user.CreatedAt, &user.UpdatedAt)
 

--- a/postgres/user_test.go
+++ b/postgres/user_test.go
@@ -27,7 +27,7 @@ func TestFindUser_Success(t *testing.T) {
 
 	repo := postgres.UserRepository{DB: db}
 
-	user, err := repo.FindUser(1)
+	user, err := repo.FindUser("WHERE id = $1", 1)
 	require.Nil(t, err)
 
 	var defaultTime time.Time
@@ -49,7 +49,7 @@ func TestFindUser_NotExists(t *testing.T) {
 
 	repo := postgres.UserRepository{DB: db}
 
-	_, err = repo.FindUser(1)
+	_, err = repo.FindUser("WHERE id = $1", 1)
 
 	require.Equal(t, easyalert.ErrRecordDoesNotExist, err)
 }

--- a/user.go
+++ b/user.go
@@ -8,7 +8,7 @@ import (
 
 // UserRepository wraps all CRUD operations for users
 type UserRepository interface {
-	FindUser(ID uint) (User, error)
+	FindUser(query string, params ...interface{}) (User, error)
 	FindUsers() ([]User, error)
 	CreateUser(user User) (User, error)
 	UpdateUser(user User) (User, error)

--- a/web/api/auth_handler.go
+++ b/web/api/auth_handler.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/bakku/easyalert"
+)
+
+// AuthHandler accepts a JSON object containing email and password.
+// It then validates this object using the database and returns the
+// users token if everything is valid.
+type AuthHandler struct {
+	UserRepo easyalert.UserRepository
+}
+
+type authRequestBody struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type authResponseBody struct {
+	Token string `json:"token"`
+}
+
+// ServeHTTP handles the HTTP request.
+func (h AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	bytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "could not read http body")
+		return
+	}
+
+	var authBody authRequestBody
+
+	err = json.Unmarshal(bytes, &authBody)
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "invalid json")
+		return
+	}
+
+	if authBody.Email == "" || authBody.Password == "" {
+		writeError(w, http.StatusBadRequest, "Empty email or password.")
+		return
+	}
+
+	user, err := h.UserRepo.FindUser("WHERE email = $1", authBody.Email)
+	if err != nil {
+		if err == easyalert.ErrRecordDoesNotExist {
+			writeError(w, http.StatusUnauthorized, "Invalid credentials.")
+			return
+		}
+
+		writeError(w, http.StatusInternalServerError, "An unknown error occured.")
+		return
+	}
+
+	if !user.ValidPassword(authBody.Password) {
+		writeError(w, http.StatusUnauthorized, "Invalid credentials.")
+		return
+	}
+
+	responseBody := authResponseBody{user.Token}
+
+	responseBodyBytes, err := json.Marshal(responseBody)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "could not marshal response body")
+		return
+	}
+
+	body, err := prettifyJSON(string(responseBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "could not prettify json response")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(body))
+}

--- a/web/api/auth_handler_test.go
+++ b/web/api/auth_handler_test.go
@@ -1,0 +1,155 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bakku/easyalert"
+	"github.com/bakku/easyalert/mocks"
+	"github.com/bakku/easyalert/web/api"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPOSTAuth_ShouldReturnErrorIfUserWasGivenIncorrectly(t *testing.T) {
+	payload := "invalid"
+
+	req, err := http.NewRequest("POST", "/api/auth", strings.NewReader(payload))
+	require.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := api.AuthHandler{}
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, rr.Code)
+	require.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
+	require.Equal(t, "{\n  \"error\": \"invalid json\"\n}", rr.Body.String())
+}
+
+func TestPOSTAuth_ShouldReturnErrorIfEmailOrPasswordAreEmpty(t *testing.T) {
+
+	payload := `
+		{
+			"email" : "",
+			"password" : ""
+		}
+	`
+
+	req, err := http.NewRequest("POST", "/api/auth", strings.NewReader(payload))
+	require.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := api.AuthHandler{}
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
+	require.Equal(t, "{\n  \"error\": \"Empty email or password.\"\n}", rr.Body.String())
+}
+
+func TestPOSTAuth_ShouldReturnErrorIfUserCouldNotBeFound(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	userRepo := mocks.NewMockUserRepository(mockCtrl)
+	userRepo.EXPECT().FindUser(gomock.Any(), gomock.Any()).Return(easyalert.User{}, easyalert.ErrRecordDoesNotExist)
+
+	payload := `
+		{
+			"email" : "test@mail.com",
+			"password" : "test1234"
+		}
+	`
+
+	req, err := http.NewRequest("POST", "/api/auth", strings.NewReader(payload))
+	require.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := api.AuthHandler{
+		UserRepo: userRepo,
+	}
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
+	require.Equal(t, "{\n  \"error\": \"Invalid credentials.\"\n}", rr.Body.String())
+}
+
+func TestPOSTAuth_ShouldReturnErrorIfPasswordWasIncorrect(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	user := easyalert.User{
+		ID:             1,
+		Email:          "test@mail.com",
+		PasswordDigest: "12345",
+		Token:          "12345",
+		Admin:          false,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	userRepo := mocks.NewMockUserRepository(mockCtrl)
+	userRepo.EXPECT().FindUser(gomock.Any(), gomock.Any()).Return(user, nil)
+
+	payload := `
+		{
+			"email" : "test@mail.com",
+			"password" : "test1234"
+		}
+	`
+
+	req, err := http.NewRequest("POST", "/api/auth", strings.NewReader(payload))
+	require.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := api.AuthHandler{
+		UserRepo: userRepo,
+	}
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
+	require.Equal(t, "{\n  \"error\": \"Invalid credentials.\"\n}", rr.Body.String())
+}
+
+func TestPOSTAuth_ShouldReturnTokenIfPasswordWasCorrect(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	user := easyalert.User{
+		ID:             1,
+		Email:          "test@mail.com",
+		PasswordDigest: "$2a$10$zWmZyQoDOafIAOX0RJSsHuyY8DLBb3q9TKbNJQDroF1XVCwtIsamC",
+		Token:          "12345",
+		Admin:          false,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	userRepo := mocks.NewMockUserRepository(mockCtrl)
+	userRepo.EXPECT().FindUser(gomock.Any(), gomock.Any()).Return(user, nil)
+
+	payload := `
+		{
+			"email" : "test@mail.com",
+			"password" : "test1234"
+		}
+	`
+
+	req, err := http.NewRequest("POST", "/api/auth", strings.NewReader(payload))
+	require.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := api.AuthHandler{
+		UserRepo: userRepo,
+	}
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "application/json; charset=UTF-8", rr.Header().Get("Content-Type"))
+	require.Equal(t, "{\n  \"token\": \"12345\"\n}", rr.Body.String())
+}

--- a/web/server.go
+++ b/web/server.go
@@ -36,9 +36,11 @@ func NewServer(port string, DB *sql.DB) *Server {
 	// api handler
 	home := api.HomeHandler{}
 	createUsers := api.CreateUsersHandler{userRepo}
+	auth := api.AuthHandler{userRepo}
 
 	router.Methods("GET").Path("/api").Handler(home)
 	router.Methods("POST").Path("/api/users").Handler(createUsers)
+	router.Methods("POST").Path("/api/auth").Handler(auth)
 
 	s.server.Handler = router
 


### PR DESCRIPTION
Fixes #3 

This PR adds the new auth endpoint at `POST /api/auth` that accepts email and password and returns the token if valid.

It also updates the FindUser query to allow more flexible querying.